### PR TITLE
[Feature] Generic int array handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,8 +10,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bit-counter"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
+ "num-traits",
  "numpy",
  "pyo3",
  "rayon",
@@ -162,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bit-counter"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -12,3 +12,4 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.24.1", features = ["extension-module"] }
 numpy = { version = "0.24"}
 rayon = { version = "1.7" }
+num-traits = "0.2.19"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Package for counting the number of one bits in a numpy array of uint8 values.
 Implemented as a Python module using Rust, providing high performance counting.
 
-
 ## Building
 
 To build this package an installation of Rust and Python with the [maturin](https://maturin.rs/)
@@ -19,7 +18,6 @@ By default the bit counting is done with a parallel map across all available
 CPUs through the use of [rayon](https://docs.rs/rayon/latest/rayon/). Number of threads
 can be configured with the environment variable `RAYON_NUM_THREADS`.
 
-
 ## Example usage
 
     import numpy as np
@@ -29,11 +27,12 @@ can be configured with the environment variable `RAYON_NUM_THREADS`.
 
     count_of_true_values = count_ones(arr)
 
-
 ## Performance
 
 When built to target a CPU with `popcnt` support the `count_ones` method
 provided is substantially faster than a naive `np.unpackbits(arr).sum()`.
+Note that a faster `bitwise_count` function was added in `numpy`
+[1.22.0](https://numpy.org/doc/1.22/release/1.22.0-notes.html#bit-count-to-compute-the-number-of-1-bits-in-an-integer).
 The `count_ones` method also doesn't require unpacking the bit packed numpy
 array, so doesn't require any addtional memory to do the calculation.
 
@@ -44,19 +43,46 @@ are packed:
 import numpy as np
 from bit_counter import count_ones
 
+np.random.seed(42)
 arr = np.packbits(np.random.choice([True, False], 100000000))
 ```
 
 Using this package on an AMD Ryzen 9 3900X 12-Core Processor yields:
+
 ```
 %timeit count_ones(arr)
 
-905 µs ± 4.64 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
+471 µs ± 46.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
 ```
 
-Compared to the simple unpack and sum case:
+Better CPU performance can be had by treating the packed array as uint64:
+
+```
+%timeit count_ones(arr.view(np.uint64))
+
+198 µs ± 47.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
+```
+
+Compared to the simple unpack and sum case with numpy 2.2.6:
+
 ```
 %timeit np.unpackbits(arr).sum()
 
-60.4 ms ± 421 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
+45.8 ms ± 879 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
+```
+
+The faster available numpy solution using `bitwise_count` is:
+
+```
+%timeit np.bitwise_count(arr).sum()
+
+7.12 ms ± 44.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+```
+
+Which is faster again when treating the packed bits as `uint64`:
+
+```
+%timeit np.bitwise_count(arr.view(np.uint64)).sum()
+
+1.14 ms ± 4.94 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "bit-counter"
+dynamic = ["version"]
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Rust",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "bit-counter"
-dynamic = ["version"]
+dynamic = ["version", "description", "description_content_type"]
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Rust",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,15 @@ macro_rules! try_extract_and_count {
 /// Used for counting up the number of one values in integer numpy arrays.
 /// Supports uint8, uint16, uint32, uint64, int8, int16, int32, and int64 dtypes.
 ///
+/// Example usage:
+///
+///     import numpy as np
+///     from bit_counter import count_ones
+///     
+///     np.random.seed(42)
+///     arr = np.packbits(np.random.choice([True, False], 100000000))
+///     popcount = count_ones(arr.view(np.uint64)) # View as uint64 for better performance
+///
 /// :param arr: Numpy integer array to count the number of one bits in.
 /// :returns: Integer of the number of bits that were one in the array.
 #[pyfunction]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,13 @@
-use numpy::PyReadonlyArrayDyn;
+use num_traits::PrimInt;
+use numpy::PyReadonlyArray1;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
-/// count_ones(arr)
-/// --
-///
-/// Count the number of ones in a numpy array of uint8.
-///
-/// Used for counting up the number of one values in a `uint8`
-/// `np.array`. The input to this method would typically be the
-/// the output of `np.packbits`.
-///
-/// :param arr: Numpy uint8 array to count the number of one bits in.
-/// :returns: Integer of the number of bits that were one in the array.
-#[pyfunction]
-fn count_ones(arr: PyReadonlyArrayDyn<u8>) -> PyResult<usize> {
+fn count_ones_generic<T>(arr: PyReadonlyArray1<T>) -> PyResult<usize>
+where
+    T: numpy::Element + PrimInt + Send + Sync,
+{
     let arr = match arr.as_slice() {
         Ok(arr) => arr,
         Err(error) => return Err(PyTypeError::new_err(error)),
@@ -27,6 +19,37 @@ fn count_ones(arr: PyReadonlyArrayDyn<u8>) -> PyResult<usize> {
         .sum::<usize>();
 
     Ok(bit_count)
+}
+
+// Macro to reduce repetition in type checking
+macro_rules! try_extract_and_count {
+    ($arr:expr, $($type:ty),+) => {
+        $(
+            if let Ok(array) = $arr.extract::<PyReadonlyArray1<$type>>() {
+                return count_ones_generic(array);
+            }
+        )+
+    };
+}
+
+/// count_ones(arr)
+/// --
+///
+/// Count the number of ones in a numpy array of integers.
+///
+/// Used for counting up the number of one values in integer numpy arrays.
+/// Supports uint8, uint16, uint32, uint64, int8, int16, int32, and int64 dtypes.
+///
+/// :param arr: Numpy integer array to count the number of one bits in.
+/// :returns: Integer of the number of bits that were one in the array.
+#[pyfunction]
+fn count_ones(arr: &Bound<'_, PyAny>) -> PyResult<usize> {
+    // Try to extract as different numpy array types based on dtype
+    try_extract_and_count!(arr, u8, u16, u32, u64, i8, i16, i32, i64);
+
+    Err(PyTypeError::new_err(
+        "Unsupported array dtype. Supported dtypes are: uint8, uint16, uint32, uint64, int8, int16, int32, int64"
+    ))
 }
 
 #[pymodule]


### PR DESCRIPTION
Handle alternate numpy array numeric types. This allows for better performance
by treating an array as 64bit values (to match 64 bit CPUs).

Bump the version to 0.3.0 for this feature.