### PR TITLE
Specify `readme` field explictly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bit-counter"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "num-traits",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bit-counter"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Package for efficiently counting the number of one bits in a numpy array."
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bit-counter"
 version = "0.3.0"
 edition = "2021"
+description = "Package for efficiently counting the number of one bits in a numpy array."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bit-counter
 
-Package for counting the number of one bits in a numpy array of uint8 values.
+Package for efficiently counting the number of one bits in a numpy array.
 Implemented as a Python module using Rust, providing high performance counting.
 
 ## Building

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ build-backend = "maturin"
 
 [project]
 name = "bit-counter"
-dynamic = ["version", "description", "description_content_type"]
+readme = "README.md"
+dynamic = ["version", "summary", "description", "description_content_type"]
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
While per the docs: https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field

    If no value is specified for this field, and a file named README.md,
    README.txt or README exists in the package root, then the name of that file
    will be used. You can suppress this behavior by setting this field to
    false. If the field is set to true, a default value of README.md will be
    assumed.

Suggests that our `README.md` would be picked up by Cargo, it appears
that the change to `maturin>=1.8.0` has meant that it isn't included as
part of Python wheel builds during our GitHub actions.

Explictly setting in Cargo.toml for maturin to use the README.md file
didn't work as expcted.

Per the `maturin` docs:

    description - From the contents of the README file specified in Cargo.toml's package.readme

Setting `readme` in `pyproject.toml` as seen elsewhere online.
e.g. in Polars `pola-rs/polars` `py-polars/pyproject.toml`, at least at
commit 4197fa1.

Downloading the artifacts from the build of this commit and inspecting with `pkginfo`
shows the description populated with the text from the README.md file.